### PR TITLE
Change IOS-XE Ansible username variable

### DIFF
--- a/iosxe/group_vars/sandbox.yml
+++ b/iosxe/group_vars/sandbox.yml
@@ -1,4 +1,4 @@
-ansible_username: 'root'
+ansible_user: 'root'
 ansible_password: 'D_Vay!_10&'
 ansible_port: 8181
 netconf_port: 10000


### PR DESCRIPTION
Modified ansible_username to ansible_user to fall inline with 2.5 network_cli conventions